### PR TITLE
Add new command options to cs-console and cs-status

### DIFF
--- a/hdr/cserver.h
+++ b/hdr/cserver.h
@@ -38,6 +38,9 @@
 /* default class name when making a connection */
 #define DEFAULTCLASSNAME 	"quark"
 
+/* default server name */
+#define DEFAULTSERVERNAME 	"xinuserver.cs.purdue.edu"
+
 /* Environment Variables */
 
 /* default class name - overrides built-in default (optional) */

--- a/programs/cs-status.c
+++ b/programs/cs-status.c
@@ -79,6 +79,10 @@ main( argc, argv )
 	if (class[0] == '\0') {
 	    strncpy( class, getdfltClass( class, connection ), MAXCLASSNAME );
 	}
+	if ( strcmp(class, "all") == 0 ) {
+	    class[ 0 ] = '\0';
+	    class[ MAXCLASSNAME - 1 ] = '\0';
+	}
 	if( ( sock = statusrequest( connection, 
 				    class,
 				    host ) ) < 0 ) 
@@ -98,7 +102,7 @@ main( argc, argv )
 printusage( sb )
      char * sb;
 {
-	fprintf( stderr, "usage: %s [-b] [-f] [-c class] [-s server] [connection]\n", sb );
+	fprintf( stderr, "usage: %s [-b] [-f] [-a] [-c class] [-s server] [connection]\n", sb );
 	fprintf( stderr,
 		 "cs-status v2.0 \"Millenium Edition\"\n");
 	exit( 1 );
@@ -150,6 +154,13 @@ printstatus( reply, fflag, bflag )
 	numc = atoi( reply->numconnections );
 	stat = (struct statusreplyData *) ( reply->details );
 	for( i = 0; i < numc; i++, stat++ ) {
+
+		/* Ignore DOWNLOAD and POWERCYCLE classes */
+		if( strcmp(stat->conclass, "DOWNLOAD") == 0 ||
+		    strcmp(stat->conclass, "POWERCYCLE") == 0) {
+			continue;
+		}
+
 		if( bflag ) {
 			if( fflag ) {
 				printf( "    " );

--- a/programs/cs-status.c
+++ b/programs/cs-status.c
@@ -79,7 +79,7 @@ main( argc, argv )
 	if (class[0] == '\0') {
 	    strncpy( class, getdfltClass( class, connection ), MAXCLASSNAME );
 	}
-	if ( strcmp(class, "all") == 0 ) {
+	if ( strequ(class, "all") ) {
 	    class[ 0 ] = '\0';
 	    class[ MAXCLASSNAME - 1 ] = '\0';
 	}
@@ -156,8 +156,8 @@ printstatus( reply, fflag, bflag )
 	for( i = 0; i < numc; i++, stat++ ) {
 
 		/* Ignore DOWNLOAD and POWERCYCLE classes */
-		if( strcmp(stat->conclass, "DOWNLOAD") == 0 ||
-		    strcmp(stat->conclass, "POWERCYCLE") == 0) {
+		if( strequ ( stat->conclass, "DOWNLOAD") ||
+		    strequ ( stat->conclass, "POWERCYCLE") ) {
 			continue;
 		}
 

--- a/programs/cs-status.c
+++ b/programs/cs-status.c
@@ -22,11 +22,13 @@ main( argc, argv )
 	int i;
 
 	host[ 0 ] = '\0';
-	host[ MAXHOSTNAME ] = '\0';
+	host[ MAXHOSTNAME - 1 ] = '\0';
 	connection[ 0 ] = '\0';
 	connection[ MAXCONNECTIONNAME - 1 ] = '\0';
 	class[ 0 ] = '\0';
 	class[ MAXCLASSNAME - 1 ] = '\0';
+
+	strncpy( host, DEFAULTSERVERNAME, MAXHOSTNAME - 1 );
 
 	for( i = 1; i < argc; i++ ) {
 		if( strequ( argv[ i ], "-h" ) ) {
@@ -55,6 +57,10 @@ main( argc, argv )
 				printusage( argv[ 0 ] );
 			}
 			strncpy( host, argv[ i ], MAXHOSTNAME - 1 );
+		}
+		else if( strequ( argv[ i ], "-a") ) {
+			host[ 0 ] = '\0';
+			host[ MAXHOSTNAME - 1 ] = '\0';
 		}
 		else if( argv[ i ][ 0 ] == '-' ) {
 			fprintf( stderr, "error: unexpected argument '%s'\n",


### PR DESCRIPTION
Some additional changes for cs-status.  Here is a summary:

cs-status when run with no parameters uses xinuserver.cs.purdue.edu as the default server
cs-status -c all prints out the status for all backends
